### PR TITLE
version 0.3

### DIFF
--- a/formatlto
+++ b/formatlto
@@ -5,11 +5,7 @@
 
 VERSION="0.3"
 SCRIPTDIR=$(dirname "${0}")
-DEPENDENCIES=(mkltfs)
-RED="$(tput setaf 1)"   # Red      - For Warnings
-GREEN="$(tput setaf 2)" # Green    - For Declarations
-BLUE="$(tput setaf 4)"  # Blue     - For Questions
-NC="$(tput sgr0)"       # No Color
+DEPENDENCIES=(mkltfs, mmfunctions)
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
 
@@ -31,39 +27,40 @@ while getopts ":fch" opt ; do
         f) FORCE=1 ;;
         c) COMPRESS=1 ;;
         h) _usage ; exit 0 ;;
-        *) echo "${RED}Error: Bad option -${OPTARG}${NC}" ; _usage ; exit 1 ;;
+        *) _report -w "Error: Bad option -${OPTARG}" ; _usage ; exit 1 ;;
     esac
 done
 
-if [ ! "${FORCE}" = "1" ] ; then
+if [ "${FORCE}" = "1" ] ; then
     MIDDLE_OPTIONS+=(-f)
-else
-    echo "${GREEN}Will force formatting.${NC}"
+    _report -d "Will force formatting."
 fi
 
 if [ ! "${COMPRESS}" = "1" ] ; then
     MIDDLE_OPTIONS+=(-c)
 else
-    echo "${GREEN}Will use compression.${NC}"
+    _report -d "Will use compression."
 fi
 
 if [ ! "${LTO_ARRAY}" ] ; then
     if [[ $(uname -s) = "Darwin" ]] ; then
-        LTO_ARRAY=($(system_profiler SPSASDataType | grep "SCSI Target Identifier" | cut -d : -f2 | sort | xargs)) # try to figure out how many lto decks are attached
+        # try to figure out how many LTO decks are attached
+        LTO_ARRAY=($(system_profiler SPSASDataType | grep "SCSI Target Identifier" | cut -d : -f2 | sort | xargs))
     else
-        LTO_ARRAY=(0) #### TO DO: itemize when there are multiple LTO drives in Linux and Windows
+        #### TO DO: itemize when there are multiple LTO drives in Linux and Windows
+        LTO_ARRAY=(0)
     fi
 fi
 
 if [[ "${#LTO_ARRAY[@]}" -gt 1 ]] ; then
-   PS3="${BLUE}Which LTO deck?${NC} "
+   PS3="\033[1;34mWhich LTO deck? \033[0m"
    eval set "${LTO_ARRAY[@]}"
    select DECK in "$@"
    do
        break
    done
    if [ ! "${DECK}" ] ; then
-       echo "${RED}Error: You selected an invalid deck.${NC}"
+       _report -w "Error: You selected an invalid deck."
        exit 1
    fi
 else
@@ -76,10 +73,10 @@ else
 fi
 
 REGEX="^[A-Z0-9]{6}(L[567])?$"
-printf "${BLUE}Enter the tape identifier:${NC} "
+_report -qn "Enter the tape identifier: "
 read TAPE_ID
 if [[ ! $(echo "${TAPE_ID}" | grep -E "${REGEX}") ]] ; then
-   echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6' or 'L7' specifying the LTO generation.${NC}"
+   _report -w "Error: The tape id must contain exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6' or 'L7' specifying the LTO generation."
    exit 1
 fi
 if [[ $(which ltfs_ldun) ]] ; then

--- a/formatlto
+++ b/formatlto
@@ -68,11 +68,11 @@ else
    fi
 fi
 
-REGEX="^[A-Z0-9]{6}$"
-printf "${BLUE}Enter the 6 character tape identifier:${NC} "
+REGEX="^[A-Z0-9]{6}(L[567])?$"
+printf "${BLUE}Enter the tape identifier:${NC} "
 read TAPE_ID
 if [[ ! $(echo "${TAPE_ID}" | grep -E "${REGEX}") ]] ; then
-   echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers.${NC}"
+   echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers, possibly followed by L5, L6 or L7.${NC}"
    exit 1
 fi
 if [[ $(which ltfs_ldun) ]] ; then

--- a/formatlto
+++ b/formatlto
@@ -3,7 +3,7 @@
 # formatlto
 # Formats an LTO tape with LTFS.
 
-VERSION="0.2"
+VERSION="0.3"
 SCRIPTDIR=$(dirname "${0}")
 DEPENDENCIES=(mkltfs)
 RED="$(tput setaf 1)"   # Red      - For Warnings

--- a/formatlto
+++ b/formatlto
@@ -61,11 +61,11 @@ if [[ "${#LTO_ARRAY[@]}" -gt 1 ]] ; then
        exit 1
    fi
 else
-   if [[ $(uname -s) = "Linux" ]] ; then
-       DECK='/dev/sg3'
-   else
+#   if [[ $(uname -s) = "Linux" ]] ; then
+#       DECK='/dev/sg3'
+#   else
        DECK=0
-   fi
+#   fi
 fi
 
 REGEX="^[A-Z0-9]{6}(L[567])?$"

--- a/formatlto
+++ b/formatlto
@@ -68,9 +68,10 @@ else
    fi
 fi
 
+REGEX="^[A-Z0-9]{6}$"
 printf "${BLUE}Enter the 6 character tape identifier:${NC} "
 read TAPE_ID
-if [[ ! $(echo "${TAPE_ID}" | grep -E "^[A-Z0-9]{6}$") ]] ; then
+if [[ ! $(echo "${TAPE_ID}" | grep -E "${REGEX}") ]] ; then
    echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers.${NC}"
    exit 1
 fi

--- a/formatlto
+++ b/formatlto
@@ -61,11 +61,11 @@ if [[ "${#LTO_ARRAY[@]}" -gt 1 ]] ; then
        exit 1
    fi
 else
-#   if [[ $(uname -s) = "Darwin" ]] ; then
+   if [[ $(uname -s) = "Linux" ]] ; then
+       DECK='/dev/sg3'
+   else
        DECK=0
-#   else
-#       DECK='/dev/sg3'
-#   fi
+   fi
 fi
 
 printf "${BLUE}Enter the 6 character tape identifier:${NC} "

--- a/formatlto
+++ b/formatlto
@@ -61,7 +61,11 @@ if [[ "${#LTO_ARRAY[@]}" -gt 1 ]] ; then
        exit 1
    fi
 else
-   DECK=0
+#   if [[ $(uname -s) = "Darwin" ]] ; then
+       DECK=0
+#   else
+#       DECK='/dev/sg3'
+#   fi
 fi
 
 printf "${BLUE}Enter the 6 character tape identifier:${NC} "

--- a/formatlto
+++ b/formatlto
@@ -14,26 +14,32 @@ NC="$(tput sgr0)"       # No Color
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
 
 _usage(){
-    echo
-    echo "$(basename "${0}") ${VERSION}"
-    echo "This script formats an LTO tape with LTFS."
-    echo "Dependencies: ${DEPENDENCIES[@]}"
-    echo "Usage: $(basename "${0}") [[-f] [-c] | -h]"
-    echo "  -f  force formating"
-    echo "  -c  use compression"
-    echo "  -h  display this help"
-    echo
+cat <<EOF
+$(basename "${0}") ${VERSION}
+This script formats an LTO tape with LTFS.
+Dependencies: ${DEPENDENCIES[@]}
+Usage: $(basename "${0}") [-f] [-c] | [-h]
+  -f  force formating
+  -c  use compression
+  -h  display this help
+EOF
 }
 
 unset MIDDLE_OPTIONS
 while getopts ":fch" opt ; do
     case "${opt}" in
-        f) MIDDLE_OPTIONS+=(-f) ;;
+        f) FORCE=1 ;;
         c) COMPRESS=1 ;;
         h) _usage ; exit 0 ;;
         *) echo "${RED}Error: Bad option -${OPTARG}${NC}" ; _usage ; exit 1 ;;
     esac
 done
+
+if [ ! "${FORCE}" = "1" ] ; then
+    MIDDLE_OPTIONS+=(-f)
+else
+    echo "${GREEN}Will force formatting.${NC}"
+fi
 
 if [ ! "${COMPRESS}" = "1" ] ; then
     MIDDLE_OPTIONS+=(-c)
@@ -45,7 +51,7 @@ if [ ! "${LTO_ARRAY}" ] ; then
     if [[ $(uname -s) = "Darwin" ]] ; then
         LTO_ARRAY=($(system_profiler SPSASDataType | grep "SCSI Target Identifier" | cut -d : -f2 | sort | xargs)) # try to figure out how many lto decks are attached
     else
-        LTO_ARRAY=(0) # to do: itemize when there are multiple lto drives in Linux and Windows
+        LTO_ARRAY=(0) #### TO DO: itemize when there are multiple LTO drives in Linux and Windows
     fi
 fi
 
@@ -61,6 +67,7 @@ if [[ "${#LTO_ARRAY[@]}" -gt 1 ]] ; then
        exit 1
    fi
 else
+#### TO DO: select the correct path to the drive on Linux and Windows
 #   if [[ $(uname -s) = "Linux" ]] ; then
 #       DECK='/dev/sg3'
 #   else
@@ -72,7 +79,7 @@ REGEX="^[A-Z0-9]{6}(L[567])?$"
 printf "${BLUE}Enter the tape identifier:${NC} "
 read TAPE_ID
 if [[ ! $(echo "${TAPE_ID}" | grep -E "${REGEX}") ]] ; then
-   echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers, possibly followed by L5, L6 or L7.${NC}"
+   echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6' or 'L7' specifying the LTO generation.${NC}"
    exit 1
 fi
 if [[ $(which ltfs_ldun) ]] ; then


### PR DESCRIPTION
- use `mmfunctions` for the messages
- update regex for both ID formats, e.g. `ABC123` and `ABC123L6`
- … and therefore update version number
- when https://github.com/amiaopensource/ltopers/compare/Linux?expand=1#diff-b7558f8cea55210673655361b05ae3feR67 is uncommented, it works on our Linux configuration, but I guess not in general