### PR TITLE
use mmfunctions & update cartridge ID format

### DIFF
--- a/formatlto
+++ b/formatlto
@@ -3,71 +3,80 @@
 # formatlto
 # Formats an LTO tape with LTFS.
 
-VERSION="0.2"
+VERSION="0.3"
 SCRIPTDIR=$(dirname "${0}")
-DEPENDENCIES=(mkltfs)
-RED="$(tput setaf 1)"   # Red      - For Warnings
-GREEN="$(tput setaf 2)" # Green    - For Declarations
-BLUE="$(tput setaf 4)"  # Blue     - For Questions
-NC="$(tput sgr0)"       # No Color
+DEPENDENCIES=(mkltfs, mmfunctions)
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
 
 _usage(){
-    echo
-    echo "$(basename "${0}") ${VERSION}"
-    echo "This script formats an LTO tape with LTFS."
-    echo "Dependencies: ${DEPENDENCIES[@]}"
-    echo "Usage: $(basename "${0}") [[-f] [-c] | -h]"
-    echo "  -f  force formating"
-    echo "  -c  use compression"
-    echo "  -h  display this help"
-    echo
+cat <<EOF
+$(basename "${0}") ${VERSION}
+This script formats an LTO tape with LTFS.
+Dependencies: ${DEPENDENCIES[@]}
+Usage: $(basename "${0}") [-f] [-c] | [-h]
+  -f  force formating
+  -c  use compression
+  -h  display this help
+EOF
 }
 
 unset MIDDLE_OPTIONS
 while getopts ":fch" opt ; do
     case "${opt}" in
-        f) MIDDLE_OPTIONS+=(-f) ;;
+        f) FORCE=1 ;;
         c) COMPRESS=1 ;;
         h) _usage ; exit 0 ;;
-        *) echo "${RED}Error: Bad option -${OPTARG}${NC}" ; _usage ; exit 1 ;;
+        *) _report -w "Error: Bad option -${OPTARG}" ; _usage ; exit 1 ;;
     esac
 done
+
+if [ "${FORCE}" = "1" ] ; then
+    MIDDLE_OPTIONS+=(-f)
+    _report -d "Will force formatting."
+fi
 
 if [ ! "${COMPRESS}" = "1" ] ; then
     MIDDLE_OPTIONS+=(-c)
 else
-    echo "${GREEN}Will use compression.${NC}"
+    _report -d "Will use compression."
 fi
 
 if [ ! "${LTO_ARRAY}" ] ; then
     if [[ $(uname -s) = "Darwin" ]] ; then
-        LTO_ARRAY=($(system_profiler SPSASDataType | grep "SCSI Target Identifier" | cut -d : -f2 | sort | xargs)) # try to figure out how many lto decks are attached
+        # try to figure out how many LTO decks are attached
+        LTO_ARRAY=($(system_profiler SPSASDataType | grep "SCSI Target Identifier" | cut -d : -f2 | sort | xargs))
     else
-        LTO_ARRAY=(0) # to do: itemize when there are multiple lto drives in Linux and Windows
+        #### TO DO: itemize when there are multiple LTO drives in Linux and Windows
+        LTO_ARRAY=(0)
     fi
 fi
 
 if [[ "${#LTO_ARRAY[@]}" -gt 1 ]] ; then
-   PS3="${BLUE}Which LTO deck?${NC} "
+   PS3="\033[1;34mWhich LTO deck? \033[0m"
    eval set "${LTO_ARRAY[@]}"
    select DECK in "$@"
    do
        break
    done
    if [ ! "${DECK}" ] ; then
-       echo "${RED}Error: You selected an invalid deck.${NC}"
+       _report -w "Error: You selected an invalid deck."
        exit 1
    fi
 else
-   DECK=0
+#### TO DO: select the correct path to the drive on Linux and Windows
+#   if [[ $(uname -s) = "Linux" ]] ; then
+#       DECK='/dev/sg3'
+#   else
+       DECK=0
+#   fi
 fi
 
-printf "${BLUE}Enter the 6 character tape identifier:${NC} "
+REGEX="^[A-Z0-9]{6}(L[567])?$"
+_report -qn "Enter the tape identifier: "
 read TAPE_ID
-if [[ ! $(echo "${TAPE_ID}" | grep -E "^[A-Z0-9]{6}$") ]] ; then
-   echo "${RED}Error: The tape id must contain exactly 6 capital letters and/or numbers.${NC}"
+if [[ ! $(echo "${TAPE_ID}" | grep -E "${REGEX}") ]] ; then
+   _report -w "Error: The tape id must contain exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6' or 'L7' specifying the LTO generation."
    exit 1
 fi
 if [[ $(which ltfs_ldun) ]] ; then


### PR DESCRIPTION
- use `mmfunctions` for the messages
- update regex for both ID formats, e.g. `ABC123` and `ABC123L6`
- … and therefore update version number
- when the lines 67–70 and 72 are uncommented, it works on our Linux configuration, but I guess not in general