### PR TITLE
unifying

### DIFF
--- a/ltoperconfig
+++ b/ltoperconfig
@@ -3,9 +3,9 @@
 # ltoperconfig
 # set up variables
 
-CONFIG="Y"
-CONFIG_VERSION="1.0"
+CONFIG_VERSION="0.9"
 SCRIPTDIR=$(dirname "${0}")
+CONFIG="Y"
 LTO_CONFIG_FILE="${SCRIPTDIR}/ltoper.conf"
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
@@ -81,29 +81,31 @@ rm "${pashua_configfile}"
 
 if [[ "$cb" = 0 ]] ; then
     #report back options
-    echo "  FILEMAKER_USER = ${FILEMAKER_USER}"
-    echo "  FILEMAKER_PASS = ${FILEMAKER_PASS}"
-    echo "  FILEMAKER_DB = ${FILEMAKER_DB}"
-    echo "  FILEMAKER_XML_URL = ${FILEMAKER_XML_URL}"
-    echo ""
+cat <<EOF
+  FILEMAKER_USER = ${FILEMAKER_USER}
+  FILEMAKER_PASS = ${FILEMAKER_PASS}
+  FILEMAKER_DB = ${FILEMAKER_DB}
+  FILEMAKER_XML_URL = ${FILEMAKER_XML_URL}
 
-    # write config file
-    {
-        echo "#$(basename "${0}") config file"
-        echo "${config_comment}"
-        echo "${FILEMAKER_USER_COMMENT}"
-        echo "FILEMAKER_USER=\"${FILEMAKER_USER}\""
-        echo
-        echo "${FILEMAKER_PASS_COMMENT}"
-        echo "FILEMAKER_PASS=\"${FILEMAKER_PASS}\""
-        echo
-        echo "${FILEMAKER_DB_COMMENT}"
-        echo "FILEMAKER_DB=\"${FILEMAKER_DB}\""
-        echo
-        echo "${FILEMAKER_XML_URL_COMMENT}"
-        echo "FILEMAKER_XML_URL=\"${FILEMAKER_XML_URL}\""
-        echo
-    } > "${LTO_CONFIG_FILE}"
+EOF
 
+# write config file
+    cat > "${LTO_CONFIG_FILE}" <<EOF
+#$(basename "${0}") config file
+${config_comment}
+${FILEMAKER_USER_COMMENT}
+FILEMAKER_USER="${FILEMAKER_USER}"
+
+${FILEMAKER_PASS_COMMENT}
+FILEMAKER_PASS="${FILEMAKER_PASS}"
+
+${FILEMAKER_DB_COMMENT}
+FILEMAKER_DB="${FILEMAKER_DB}"
+
+${FILEMAKER_XML_URL_COMMENT}
+FILEMAKER_XML_URL="${FILEMAKER_XML_URL}"
+
+EOF
+ 
     . "${LTO_CONFIG_FILE}"
 fi


### PR DESCRIPTION
- for readability and maintenance use `cat` instead of multiple `echo`
- uniform variable order through the scripts
- change version from `1.0` to… `0.9` (the idea is to prepare a global release `1.0.0` of LTOpers)