### PR TITLE
sterilize ALL dashes

### DIFF
--- a/searchlto
+++ b/searchlto
@@ -91,7 +91,7 @@ while ! [[ "${*}" = "" ]] ; do
     else
         SQL_RESULTS=$(mysql --login-path="${PREMIS_PROFILE}" "${PREMIS_NAME}" -B -e "SELECT ltoID,filePath FROM ltoSchema WHERE ltoID='${SEARCH_TERM}'")
         if [ -z "${SQL_RESULTS}" ] ; then
-            BOOLEAN_TERM=$(echo "+${SEARCH_TERM}" | sed -e "s/ - / /g" | sed -e "s/ / +/g" )
+            BOOLEAN_TERM=$(echo "+${SEARCH_TERM}" | sed -e "s/-/ /g" | tr -s ' ' | sed -e "s/ / +/g" )
             SQL_RESULTS=$(mysql --login-path="${PREMIS_PROFILE}" "${PREMIS_NAME}" -B -e "SELECT ltoID,filePath FROM ltoSchema WHERE MATCH(filePath) AGAINST ('${BOOLEAN_TERM}' IN BOOLEAN MODE)")
         fi
     fi


### PR DESCRIPTION
Makes boolean search accurate for file names that contain dashes inside words or numbers. (As opposed to surrounded with spaces)