### PR TITLE
LTO_LOGS needed defined

### DIFF
--- a/writelto
+++ b/writelto
@@ -12,6 +12,8 @@ TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[567])?$"
 HIDDEN_FILES=""
 TAPE_EJECT="Y"
 _check_for_lto_index_dir
+LTO_LOGS="${LTO_INDEX_DIR}"
+printf "LTO_LOGS = ${LTO_INDEX_DIR}"
 
 if [[ $(dirname $(which "${0}")) = "/usr/local/bin" || $(dirname $(which "${0}")) = "${HOME}/.linuxbrew/bin" ]] ; then
     VERSION=$(TMP=$(brew info ltopers | grep -Eo "/ltopers/.* \(") ; echo ${TMP:9:(${#TMP}-11)})


### PR DESCRIPTION
LTO_LOGS needed defined to $LTO_INDEX_DIR from mmconfig or logs would attempt to write to /

added in printf to confirm location of LTO_LOGS before script runs