### PR TITLE
lto_logs bug fixes

### DIFF
--- a/indexschemas
+++ b/indexschemas
@@ -7,6 +7,7 @@ SCRIPTDIR=$(dirname "${0}")
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
 
+_check_for_lto_index_dir
 LTO_LOGS="${LTO_INDEX_DIR}"
 
 if [[ $(dirname $(which "${0}")) = "/usr/local/bin" || $(dirname $(which "${0}")) = "${HOME}/.linuxbrew/bin" ]] ; then

--- a/mountlto
+++ b/mountlto
@@ -16,7 +16,8 @@ fi
 
 unset LTO_COUNT
 unset LTFS_OPTIONS
-LTO_LOGS="${HOME}/Documents/lto_indexes"
+_check_for_lto_index_dir
+LTO_LOGS="${LTO_INDEX_DIR}"
 if [[ "$(uname -s)" = "Darwin" ]] ; then
     # try to figure out how many lto decks are attached
     LTO_COUNT=$(system_profiler SPSASDataType | grep "SCSI Target Identifier" | wc -l | awk '{print $1}')
@@ -79,7 +80,7 @@ for i in $(seq 1 "$LTO_COUNT") ; do
         LTFS_OPTIONS+=(-o volname="${TAPE_SERIAL}")
         LTFS_OPTIONS+=(-o uid=$(id -u))
 
-        ltfs -f -o work_directory="$LTO_LOGS" ${LTFS_OPTIONS[@]} "${MOUNT_DIR}"
+        ltfs -f -o work_directory="${LTO_LOGS}" ${LTFS_OPTIONS[@]} "${MOUNT_DIR}"
         [ -d "${MOUNT_DIR}" ] && rmdir "${MOUNT_DIR}"
         renameschemas -u
         break

--- a/renameschemas
+++ b/renameschemas
@@ -38,6 +38,7 @@ while getopts ":uh" opt ; do
 done
 shift $(( ${OPTIND} - 1 ))
 
+_check_for_lto_index_dir
 LTO_LOGS="${LTO_INDEX_DIR}"
 OLD_LOGS="${LTO_LOGS}/old/"
 

--- a/verifylto
+++ b/verifylto
@@ -9,6 +9,7 @@ SCRIPTDIR=$(dirname "${0}")
 HIDDEN_FILES=""
 TAPE_MOUNT_POINT="/Volumes"
 TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[567])?$"
+_check_for_lto_index_dir
 LTO_LOGS="${LTO_INDEX_DIR}"
 TAPE_EJECT="Y"
 

--- a/writelto
+++ b/writelto
@@ -119,9 +119,7 @@ echo -n "$(date +%FT%T) " >> "${LTO_LOGS}/tape_capacity.txt"
 echo $(df -Ph "${TAPE_PATH}" | tail -n 1) >> "${LTO_LOGS}/tape_capacity.txt"
 
 renameschemas -u
-SCHEMADIR="${LTO_LOGS}/schema"
-_mkdir2 "${SCHEMADIR}"
-SCHEMA_FILE="${SCHEMADIR}/${TAPE_SERIAL}.schema"
+SCHEMA_FILE="${LTO_LOGS}/${TAPE_SERIAL}.schema"
 
 printf "\nrsync error report written to:\n\t%s/%s_writelto.txt" "${WRITELTODIR}" "${TAPE_SERIAL}"
 printf "\nreadback checksums written to:\n\t%s" "${READBACKOUTPUT}"


### PR DESCRIPTION
Cleaning up lto_logs location assignments - should now consistently check for LTO_INDEX_DIR in mmconfig (and default to ${HOME}/Documents/lto_indexes otherwise)