### PR TITLE
mountlto housekeeping

### DIFF
--- a/mountlto
+++ b/mountlto
@@ -3,16 +3,10 @@
 # mountlto
 
 SCRIPTDIR=$(dirname "${0}")
-DEPENDENCIES=(mmfunctions) #### TO DO
+DEPENDENCIES=(mmfunctions)
 MINIMUM_TAPE_SERIAL_LENGTH=2
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
-
-if [[ $(dirname $(which "${0}")) = "/usr/local/bin" || $(dirname $(which "${0}")) = "${HOME}/.linuxbrew/bin" ]] ; then
-    VERSION=$(TMP=$(brew info ltopers | grep -Eo "/ltopers/.* \(") ; echo ${TMP:9:(${#TMP}-11)})
-else
-    VERSION=""
-fi
 
 unset LTO_COUNT
 unset LTFS_OPTIONS
@@ -41,7 +35,7 @@ for i in $(seq 1 "$LTO_COUNT") ; do
         ltfs_ldun load ${DECK} 1>/dev/null
     fi
     LOADTMP=$(_maketemp)
-    TAPE_SERIAL=""
+    unset TAPE_SERIAL
     COUNTER=0
     echo -n "Checking for tape barcode"
     while [[ "${#TAPE_SERIAL}" -lt "${MINIMUM_TAPE_SERIAL_LENGTH}" ]] && [[ "$COUNTER" -lt 5 ]]; do
@@ -57,7 +51,7 @@ for i in $(seq 1 "$LTO_COUNT") ; do
             DECKSERIAL=$(cat "$LOADTMP" | grep -a -o "serial number is [A-Z0-9]*" | awk '{print $4}')
             TAPE_SERIAL="${DECKSERIAL}"
         else
-            TAPE_SERIAL=""
+            unset TAPE_SERIAL
         fi
     fi
     if [[ "${#TAPE_SERIAL}" -ge "${MINIMUM_TAPE_SERIAL_LENGTH}" ]] ; then

--- a/mountlto
+++ b/mountlto
@@ -3,7 +3,7 @@
 # mountlto
 
 SCRIPTDIR=$(dirname "${0}")
-DEPENDENCIES=(mmfunctions)
+DEPENDENCIES=(ltfs mmfunctions)
 MINIMUM_TAPE_SERIAL_LENGTH=2
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }


### PR DESCRIPTION
- delete `${VERSION}`, because it’s not used in this function
- use `unset` for empty variables