### PR TITLE
force tape serial to 6 char

### DIFF
--- a/formatlto
+++ b/formatlto
@@ -5,7 +5,7 @@
 
 SCRIPTDIR=$(dirname "${0}")
 DEPENDENCIES=(mkltfs mmfunctions)
-TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[5-8])?$"
+TAPE_SERIAL_REGEX="^[A-Z0-9]{6}$"
 BLUE="$(tput setaf 4)"  # Blue     - For Questions
 NC="$(tput sgr0)"       # No Color
 
@@ -82,7 +82,7 @@ fi
 _report -qn "Enter the tape identifier: "
 read TAPE_ID
 if [[ ! $(echo "${TAPE_ID}" | grep -E "${TAPE_SERIAL_REGEX}") ]] ; then
-    _report -w "Error: The tape id must be exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6', 'L7' or 'L8' specifying the LTO generation."
+    _report -w "Error: The tape id must be exactly 6 capital letters and/or numbers."
     exit 1
 fi
 mkltfs ${MIDDLE_OPTIONS[@]} --device=${DECK} --tape-serial="${TAPE_ID}" --volume-name="${TAPE_ID}"

--- a/readlto
+++ b/readlto
@@ -6,7 +6,7 @@
 SCRIPTDIR=$(dirname "${0}")
 DEPENDENCIES=(gcp)
 TAPE_MOUNT_POINT="/Volumes"
-TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[5-8])?$"
+TAPE_SERIAL_REGEX="^[A-Z0-9]{6}$"
 TAPE_EJECT="Y"
 
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
@@ -43,7 +43,7 @@ shift $(( ${OPTIND} - 1 ))
 
 TARGET="${1}"
 if [[ ! $(echo "${TAPE_SERIAL}" | grep -E "${TAPE_SERIAL_REGEX}") ]] ; then
-    echo "${TAPE_SERIAL} is not valid. The tape id must be exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6', 'L7' or 'L8' specifying the LTO generation."
+    echo "${TAPE_SERIAL} is not valid. The tape id must be exactly 6 capital letters and/or numbers."
     exit 1
 fi
 

--- a/verifylto
+++ b/verifylto
@@ -8,7 +8,7 @@
 SCRIPTDIR=$(dirname "${0}")
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
 TAPE_MOUNT_POINT="/Volumes"
-TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[5-8])?$"
+TAPE_SERIAL_REGEX="^[A-Z0-9]{6}$"
 _check_for_lto_index_dir
 LTO_LOGS="${LTO_INDEX_DIR}"
 TAPE_EJECT="Y"
@@ -50,7 +50,7 @@ if [[ "${PREMIS_DB}" = "Y" ]] ; then
     _report_to_db
 fi
 if [[ ! $(echo "${TAPE_SERIAL}" | grep -E "${TAPE_SERIAL_REGEX}") ]] ; then
-    echo "${TAPE_SERIAL} is not valid. The tape id must be exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6', 'L7' or 'L8' specifying the LTO generation."
+    echo "${TAPE_SERIAL} is not valid. The tape id must be exactly 6 capital letters and/or numbers."
     exit 1
 fi
 

--- a/writelto
+++ b/writelto
@@ -8,7 +8,7 @@ SCRIPTDIR=$(dirname "${0}")
 . "${SCRIPTDIR}/mmfunctions" || { echo "Missing '${SCRIPTDIR}/mmfunctions'. Exiting." ; exit 1 ; }
 DEPENDENCIES=(gcp mmfunctions)
 TAPE_MOUNT_POINT="/Volumes"
-TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[5-8])?$"
+TAPE_SERIAL_REGEX="^[A-Z0-9]{6}$"
 unset HIDDEN_FILES
 TAPE_EJECT="Y"
 _check_for_lto_index_dir
@@ -59,7 +59,7 @@ shift $(( ${OPTIND} - 1 ))
 
 SOURCE_DIR="${1}"
 if [[ ! $(echo "${TAPE_SERIAL}" | grep -E "${TAPE_SERIAL_REGEX}") ]] ; then
-    _report -w "Tape serial ${TAPE_SERIAL} is not valid. The tape id must be exactly 6 capital letters and/or numbers, possibly followed by 'L5', 'L6', 'L7' or 'L8' specifying the LTO generation."
+    _report -w "Tape serial ${TAPE_SERIAL} is not valid. The tape id must be exactly 6 capital letters and/or numbers."
     _report -w "Proceeding with non-standard Tape Serial"
 fi
 # Check for colons in filenames of source directory.


### PR DESCRIPTION
attempts to resolve https://github.com/amiaopensource/ltopers/issues/164 as 3 mkltfs source codes surveyed require 6 char tape serials. I'm uncertain yet if the `ltfs` based scripts require the same restriction.