### PR TITLE
Added ;; to end of TAPE_SERIAL_REGEX

### DIFF
--- a/writelto
+++ b/writelto
@@ -51,7 +51,7 @@ while getopts ":t:e:vxh" opt ; do
         t) TAPE_SERIAL="${OPTARG}" ;;
         e) TAPE_EJECT="${OPTARG}" ;;
         v) VERIFY="Y" ;;
-        x) TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[5-8]|M8)$"
+        x) TAPE_SERIAL_REGEX="^[A-Z0-9]{6}(L[5-8]|M8)$" ;;
         h) _usage ; exit 0 ;;
         :) echo "Option -${OPTARG} requires an argument" ; exit 1 ;;
         *) echo "Bad option -${OPTARG}" ; _usage ; exit 1 ;;


### PR DESCRIPTION
I think ;; is missing from the end of line 54, the TAPE_SERIAL_REGEX option. 