### PR TITLE
nicer output

### DIFF
--- a/ltopers.1
+++ b/ltopers.1
@@ -1,4 +1,8 @@
 .TH ltopers 1 "https://github.com/amiaopensource/ltopers" "2018\-07\-29" "AMIA Open Source"
+.\" Turn off justification for nroff.
+.if n .ad l
+.\" Turn off hyphenation.
+.nh
 .SH NAME
 LTOpers \- Scripts to manage LTO cartridges with LTFS
 .SH SYNOPSIS


### PR DESCRIPTION
- turn off justification for `nroff`
- turn off hyphenation, because it makes many mistakes in technical documents